### PR TITLE
use locally installed react-stdio

### DIFF
--- a/lib/react_phx_stdio/react_io.ex
+++ b/lib/react_phx_stdio/react_io.ex
@@ -1,3 +1,3 @@
 defmodule ReactPhxStdio.ReactIo do
-  use StdJsonIo, otp_app: :react_phx_stdio, script: "react-stdio"
+  use StdJsonIo, otp_app: :react_phx_stdio, script: "./node_modules/react-stdio/bin/react-stdio"
 end


### PR DESCRIPTION
This caught me, because package.json specifies a version of `react-stdio` which works out of the box as expected, and at the time I unknowingly `npm install`ed a newer version which doesn't.

It seems like a good idea to use the locally installed instance anyway :)
